### PR TITLE
Fixes applied to the .gitignore-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.jar
 *.war
 *.ear
+# Eclips fixes #
+war/
+build/
+bin/
+.externalToolBuilders/


### PR DESCRIPTION
Fixes applied to the .gitignore-file to make git ignore files and folders created by the build script.
